### PR TITLE
fix: Remove dependecy in man ci

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -12,7 +12,6 @@ jobs:
     timeout-minutes: 30
     env:
       REGISTRY_NAME: registry.digitalocean.com/kristien-docr
-    needs: [ build ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
changes:
- remove unnecessary dependency to non-existent job in `main-ci`